### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -38,3 +38,6 @@ extra-deps:
   - validity-vector
 nix:
   path: [ "nixpkgs=https://github.com/NixOS/nixpkgs/archive/886871538c15681575925a990a3f1b68ed9d5477.tar.gz" ]
+
+
+pvp-bounds: both


### PR DESCRIPTION
This automatically sets the meta-data in the generated src tarballs more accurately and reduces the
risk of this package's meta-data bitrotting over time. Addresses #5

See also https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds