### PR TITLE
Add ability to move text cursor by words

### DIFF
--- a/cursor-gen/src/Cursor/Text/Gen.hs
+++ b/cursor-gen/src/Cursor/Text/Gen.hs
@@ -1,10 +1,11 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cursor.Text.Gen
-  ( genSafeChar,
-    genTextCursorChar,
-    textCursorWithGen,
-    textCursorWithIndex0,
+  ( genSafeChar
+  , genTextCursorChar
+  , textCursorSentenceGen
+  , textCursorWithGen
+  , textCursorWithIndex0
   )
 where
 
@@ -24,6 +25,9 @@ instance GenValid TextCursor where
 genSafeChar :: Gen Char
 genSafeChar = choose (minBound, maxBound) `suchThat` isSafeChar
 
+genSpaceChar :: Gen Char
+genSpaceChar = elements [' ', '\t', '\v']
+
 genTextCursorChar :: Gen Char
 genTextCursorChar = genSafeChar `suchThat` (/= '\n')
 
@@ -32,3 +36,9 @@ textCursorWithGen gen = TextCursor <$> listCursorWithGen gen
 
 textCursorWithIndex0 :: Gen Char -> Gen TextCursor
 textCursorWithIndex0 gen = TextCursor <$> listCursorWithIndex0 gen
+
+textCursorSentenceGen :: Gen TextCursor
+textCursorSentenceGen = TextCursor <$> listCursorWithGen sentenceGen
+  where
+    sentenceGen :: Gen Char
+    sentenceGen = frequency [(1, genSpaceChar), (9, genSafeChar)]

--- a/cursor-gen/src/Cursor/Text/Gen.hs
+++ b/cursor-gen/src/Cursor/Text/Gen.hs
@@ -1,17 +1,20 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cursor.Text.Gen
-  ( genSafeChar
-  , genTextCursorChar
-  , textCursorSentenceGen
-  , textCursorWithGen
-  , textCursorWithIndex0
+  ( genSafeChar,
+    genTextCursorChar,
+    textCursorSentenceGen,
+    textCursorWithGen,
+    textCursorWithIndex0,
+    shrinkSentence,
   )
 where
 
+import Cursor.List
 import Cursor.List.Gen
 import Cursor.Text
 import Cursor.Types
+import Data.Char (isSpace)
 import Data.GenValidity
 import Data.GenValidity.Text ()
 import Test.QuickCheck
@@ -38,7 +41,16 @@ textCursorWithIndex0 :: Gen Char -> Gen TextCursor
 textCursorWithIndex0 gen = TextCursor <$> listCursorWithIndex0 gen
 
 textCursorSentenceGen :: Gen TextCursor
-textCursorSentenceGen = TextCursor <$> listCursorWithGen sentenceGen
+textCursorSentenceGen = textCursorWithGen sentenceGen
   where
     sentenceGen :: Gen Char
-    sentenceGen = frequency [(1, genSpaceChar), (9, genSafeChar)]
+    sentenceGen = frequency [(1, genSpaceChar), (5, genSafeChar)]
+
+shrinkSentence :: TextCursor -> [TextCursor]
+shrinkSentence tc@(TextCursor (ListCursor before after)) =
+  filter (/= tc) [TextCursor (ListCursor (map f before) (map f after))]
+  where
+    f :: Char -> Char
+    f x
+      | isSpace x = ' '
+      | otherwise = 'a'

--- a/cursor-gen/test/Cursor/ListSpec.hs
+++ b/cursor-gen/test/Cursor/ListSpec.hs
@@ -61,6 +61,22 @@ spec = do
   describe "listCursorNextItem" $ do
     it "produces valid items" $ producesValidsOnValids (listCursorNextItem @Bool)
     it "returns the item after the position" pending
+  describe "listCursorPrevUntil" $ do
+    it "produces valid cursors" $ producesValidsOnValids (listCursorPrevUntil @Bool id)
+    it "produces a cursor where the previous item either satisfies the predicate or is empty" $ forAllValid $ \cursor -> do
+      let predicate = id
+          result = listCursorPrevUntil @Bool predicate cursor
+      case listCursorPrevItem result of
+        Just item -> item `shouldSatisfy` predicate
+        Nothing -> pure ()
+  describe "listCursorNextUntil" $ do
+    it "produces valid cursors" $ producesValidsOnValids (listCursorNextUntil @Bool id)
+    it "produces a cursor where the previous item either satisfies the predicate or is empty" $ forAllValid $ \cursor -> do
+      let predicate = id
+          result = listCursorNextUntil @Bool predicate cursor
+      case listCursorNextItem result of
+        Just item -> item `shouldSatisfy` predicate
+        Nothing -> pure ()
   describe "listCursorSelectStart" $ do
     it "produces valid cursors" $ producesValidsOnValids (listCursorSelectStart @Bool)
     it "is a movement" $ isMovement listCursorSelectStart

--- a/cursor-gen/test/Cursor/TextFieldSpec.hs
+++ b/cursor-gen/test/Cursor/TextFieldSpec.hs
@@ -8,8 +8,6 @@ module Cursor.TextFieldSpec
   )
 where
 
--- import Test.Validity.Optics
-
 import Control.Monad
 import Cursor.List.NonEmpty
 import Cursor.TextField
@@ -135,6 +133,18 @@ spec = do
   describe "textFieldCursorSelectNextChar" $ do
     it "produces valid cursors" $ producesValidsOnValids textFieldCursorSelectNextChar
     it "selects the previous character on the current line" pending
+  describe "textFieldCursorSelectBeginWord"
+    $ it "produces valid cursors"
+    $ producesValidsOnValids textFieldCursorSelectBeginWord
+  describe "textFieldCursorSelectEndWord"
+    $ it "produces valid cursors"
+    $ producesValidsOnValids textFieldCursorSelectEndWord
+  describe "textFieldCursorSelectPrevWord"
+    $ it "produces valid cursors"
+    $ producesValidsOnValids textFieldCursorSelectPrevWord
+  describe "textFieldCursorSelectNextWord"
+    $ it "produces valid cursors"
+    $ producesValidsOnValids textFieldCursorSelectNextWord
   describe "textFieldCursorIndexOnLine" $ do
     it "produces valid indices" $ producesValidsOnValids textFieldCursorIndexOnLine
     it "returns the index on the current line" pending

--- a/cursor-gen/test/Cursor/TextSpec.hs
+++ b/cursor-gen/test/Cursor/TextSpec.hs
@@ -10,8 +10,9 @@ where
 import Control.Monad
 import Cursor.List
 import Cursor.Text
-import Cursor.Text.Gen (textCursorSentenceGen)
+import Cursor.Text.Gen
 import Data.Char
+import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Hspec
 import Test.QuickCheck
@@ -85,40 +86,60 @@ spec = do
   describe "textCursorNextChar" $ do
     it "produces valid items" $ producesValidsOnValids textCursorNextChar
     it "returns the item after the position" pending
-  describe "textCursorBeginWord" $ do
-    it "produces valid items" $ producesValidsOnValids textCursorBeginWord
-    it "is idempotent" $ isMovementIdempotent textCursorBeginWord
-  describe "textCursorEndWord" $ do
-    it "produces valid items" $ producesValidsOnValids textCursorEndWord
-    it "is idempotent" $ isMovementIdempotent textCursorEndWord
-  describe "textCursorPrevWord" $ do
-    it "produces valid items" $ producesValidsOnValids textCursorPrevWord
-    it "goes to the beginning of the cursor" $
-      let
-        input = TextCursor {textCursorList = ListCursor {listCursorPrev = "a", listCursorNext = "\vb"}}
-        outp = TextCursor {textCursorList = ListCursor {listCursorPrev = "", listCursorNext = "a\vb"}}
-      in
-        textCursorPrevWord input `shouldBe` outp
-    it "chooses the previous word correctly" $
-      let
-        input = TextCursor {textCursorList = ListCursor {listCursorPrev = "b a", listCursorNext = " c"}}
-        outp = TextCursor {textCursorList = ListCursor {listCursorPrev = "a", listCursorNext = " b c"}}
-      in
-        textCursorPrevWord input `shouldBe` outp
-  describe "textCursorNextWord" $ do
-    it "produces valid items" $ producesValidsOnValids textCursorNextWord
+  describe "textCursorSelectBeginWord" $ do
+    it "produces valid items" $ producesValidsOnValids textCursorSelectBeginWord
+    it "is a movement" $ isMovement textCursorSelectBeginWord
+    it "is idempotent" $ isIdempotentForSentence textCursorSelectBeginWord
+    it "works for this example" $
+      textCursorSelectBeginWord (buildTestTextCursor "hell" "o") `shouldBe` buildTestTextCursor "" "hello"
+    it "works for this example" $
+      textCursorSelectBeginWord (buildTestTextCursor "hello  " " world") `shouldBe` buildTestTextCursor "" "hello   world"
+    it "works for this example" $
+      textCursorSelectBeginWord (buildTestTextCursor "hello " "world") `shouldBe` buildTestTextCursor "hello " "world"
+    it "works for this example" $
+      textCursorSelectBeginWord (buildTestTextCursor "" " hello") `shouldBe` buildTestTextCursor "" " hello"
+  describe "textCursorSelectEndWord" $ do
+    it "produces valid items" $ producesValidsOnValids textCursorSelectEndWord
+    it "is a movement" $ isMovement textCursorSelectEndWord
+    it "is idempotent" $ isIdempotentForSentence textCursorSelectEndWord
+    it "works for this example" $
+      textCursorSelectEndWord (buildTestTextCursor "hell" "o") `shouldBe` buildTestTextCursor "hello" ""
+    it "works for this example" $
+      textCursorSelectEndWord (buildTestTextCursor "hello  " " world") `shouldBe` buildTestTextCursor "hello   world" ""
+    it "works for this example" $
+      textCursorSelectEndWord (buildTestTextCursor "hello" " world") `shouldBe` buildTestTextCursor "hello" " world"
+    it "works for this example" $
+      textCursorSelectEndWord (buildTestTextCursor "hello " "") `shouldBe` buildTestTextCursor "hello " ""
+  describe "textCursorSelectNextWord" $ do
+    it "produces valid items" $ producesValidsOnValids textCursorSelectNextWord
+    it "is a movement" $ isMovement textCursorSelectNextWord
+    it "works for this example" $
+      textCursorSelectNextWord (buildTestTextCursor "" "hello") `shouldBe` buildTestTextCursor "hello" ""
+    it "works for this example" $
+      textCursorSelectNextWord (buildTestTextCursor "hell" "o world") `shouldBe` buildTestTextCursor "hello " "world"
+    it "works for this example" $
+      textCursorSelectNextWord (buildTestTextCursor "hello" " world") `shouldBe` buildTestTextCursor "hello " "world"
+    it "works for this example" $
+      textCursorSelectNextWord (buildTestTextCursor "hello " "") `shouldBe` buildTestTextCursor "hello " ""
     it "goes to the end of the cursor" $
-      let
-        input = TextCursor {textCursorList = ListCursor {listCursorPrev = "\va", listCursorNext = "b"}}
-        outp = TextCursor {textCursorList = ListCursor {listCursorPrev = "b\va", listCursorNext = ""}}
-      in
-        textCursorNextWord input `shouldBe` outp
+      textCursorSelectNextWord (buildTestTextCursor "a\v" "b") `shouldBe` buildTestTextCursor "a\vb" ""
     it "chooses the next word correctly" $
-      let
-        input = TextCursor {textCursorList = ListCursor {listCursorPrev = "a", listCursorNext = " b c"}}
-        outp = TextCursor {textCursorList = ListCursor {listCursorPrev = " a", listCursorNext = "b c"}}
-      in
-        textCursorNextWord input `shouldBe` outp
+      textCursorSelectNextWord (buildTestTextCursor "a" " b c") `shouldBe` buildTestTextCursor "a " "b c"
+  describe "textCursorSelectPrevWord" $ do
+    it "produces valid items" $ producesValidsOnValids textCursorSelectPrevWord
+    it "is a movement" $ isMovement textCursorSelectPrevWord
+    it "works for this example" $
+      textCursorSelectPrevWord (buildTestTextCursor "hello" "") `shouldBe` buildTestTextCursor "" "hello"
+    it "works for this example" $
+      textCursorSelectPrevWord (buildTestTextCursor "hello w" "orld") `shouldBe` buildTestTextCursor "hello" " world"
+    it "works for this example" $
+      textCursorSelectPrevWord (buildTestTextCursor "hello " "world") `shouldBe` buildTestTextCursor "hello" " world"
+    it "works for this example" $
+      textCursorSelectPrevWord (buildTestTextCursor " h" "ello") `shouldBe` buildTestTextCursor "" " hello"
+    it "goes to the beginning of the cursor" $
+      textCursorSelectPrevWord (buildTestTextCursor "a" "\vb") `shouldBe` buildTestTextCursor "" "a\vb"
+    it "chooses the previous word correctly" $
+      textCursorSelectPrevWord (buildTestTextCursor "a b" " c") `shouldBe` buildTestTextCursor "a" " b c"
   describe "textCursorInsert" $ do
     it "produces valids" $ forAllValid $ \d -> producesValidsOnValids (textCursorInsert d)
     it "inserts an item before the cursor" pending
@@ -185,13 +206,13 @@ isMovement :: (TextCursor -> TextCursor) -> Property
 isMovement func =
   forAllValid $ \lec -> rebuildTextCursor lec `shouldBe` rebuildTextCursor (func lec)
 
-prop_idempotent :: Eq a => (a -> a) -> a -> Bool
-prop_idempotent f x = f (f x) == f x
-
-isMovementIdempotent :: (TextCursor -> TextCursor) -> Property
-isMovementIdempotent f =
-  forAll textCursorSentenceGen $ \tc ->
+isIdempotentForSentence :: (TextCursor -> TextCursor) -> Property
+isIdempotentForSentence f =
+  checkCoverage $ forAllShrink textCursorSentenceGen shrinkSentence $ \tc ->
     let txt = rebuildTextCursor tc
         numChars = T.length txt
         numSpaces = T.length . T.filter isSpace $ txt
-     in numSpaces >= 1 ==> cover 90 (numChars > 2) "non trivial" (prop_idempotent f tc)
+     in cover 50 (numSpaces >= 1 && numChars > 2) "non trivial" $ f (f tc) `shouldBe` f tc
+
+buildTestTextCursor :: Text -> Text -> TextCursor
+buildTestTextCursor befores afters = TextCursor {textCursorList = ListCursor {listCursorPrev = T.unpack . T.reverse $ befores, listCursorNext = T.unpack afters}}

--- a/cursor/src/Cursor/List.hs
+++ b/cursor/src/Cursor/List.hs
@@ -4,33 +4,33 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Cursor.List
-  ( ListCursor(..)
-  , emptyListCursor
-  , makeListCursor
-  , makeListCursorWithSelection
-  , rebuildListCursor
-  , listCursorNull
-  , listCursorLength
-  , listCursorIndex
-  , listCursorSelectPrev
-  , listCursorSelectNext
-  , listCursorSelectIndex
-  , listCursorSelectStart
-  , listCursorSelectEnd
-  , listCursorPrevItem
-  , listCursorNextItem
-  , listCursorPrevUntil
-  , listCursorNextUntil
-  , listCursorInsert
-  , listCursorAppend
-  , listCursorInsertList
-  , listCursorAppendList
-  , listCursorRemove
-  , listCursorDelete
-  , listCursorSplit
-  , listCursorCombine
-  , traverseListCursor
-  , foldListCursor
+  ( ListCursor (..),
+    emptyListCursor,
+    makeListCursor,
+    makeListCursorWithSelection,
+    rebuildListCursor,
+    listCursorNull,
+    listCursorLength,
+    listCursorIndex,
+    listCursorSelectPrev,
+    listCursorSelectNext,
+    listCursorSelectIndex,
+    listCursorSelectStart,
+    listCursorSelectEnd,
+    listCursorPrevItem,
+    listCursorNextItem,
+    listCursorPrevUntil,
+    listCursorNextUntil,
+    listCursorInsert,
+    listCursorAppend,
+    listCursorInsertList,
+    listCursorAppendList,
+    listCursorRemove,
+    listCursorDelete,
+    listCursorSplit,
+    listCursorCombine,
+    traverseListCursor,
+    foldListCursor,
   )
 where
 
@@ -118,26 +118,24 @@ listCursorNextItem lc =
     (c : _) -> Just c
 
 listCursorPrevUntil :: (a -> Bool) -> ListCursor a -> ListCursor a
-listCursorPrevUntil p' = go p'
+listCursorPrevUntil p = go
   where
-    go :: (a -> Bool) -> ListCursor a -> ListCursor a
-    go p lc =
+    go lc =
       case listCursorPrev lc of
         [] -> lc
-        (c:_)
+        (c : _)
           | p c -> lc
-        _ -> maybe lc (go p) (listCursorSelectPrev lc)
+        _ -> maybe lc go (listCursorSelectPrev lc)
 
 listCursorNextUntil :: (a -> Bool) -> ListCursor a -> ListCursor a
-listCursorNextUntil p' = go p'
+listCursorNextUntil p = go
   where
-    go :: (a -> Bool) -> ListCursor a -> ListCursor a
-    go p lc =
+    go lc =
       case listCursorNext lc of
         [] -> lc
-        (c:_)
+        (c : _)
           | p c -> lc
-        _ -> maybe lc (go p) (listCursorSelectNext lc)
+        _ -> maybe lc go (listCursorSelectNext lc)
 
 listCursorInsert :: a -> ListCursor a -> ListCursor a
 listCursorInsert c lc = lc {listCursorPrev = c : listCursorPrev lc}

--- a/cursor/src/Cursor/List.hs
+++ b/cursor/src/Cursor/List.hs
@@ -4,31 +4,33 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Cursor.List
-  ( ListCursor (..),
-    emptyListCursor,
-    makeListCursor,
-    makeListCursorWithSelection,
-    rebuildListCursor,
-    listCursorNull,
-    listCursorLength,
-    listCursorIndex,
-    listCursorSelectPrev,
-    listCursorSelectNext,
-    listCursorSelectIndex,
-    listCursorSelectStart,
-    listCursorSelectEnd,
-    listCursorPrevItem,
-    listCursorNextItem,
-    listCursorInsert,
-    listCursorAppend,
-    listCursorInsertList,
-    listCursorAppendList,
-    listCursorRemove,
-    listCursorDelete,
-    listCursorSplit,
-    listCursorCombine,
-    traverseListCursor,
-    foldListCursor,
+  ( ListCursor(..)
+  , emptyListCursor
+  , makeListCursor
+  , makeListCursorWithSelection
+  , rebuildListCursor
+  , listCursorNull
+  , listCursorLength
+  , listCursorIndex
+  , listCursorSelectPrev
+  , listCursorSelectNext
+  , listCursorSelectIndex
+  , listCursorSelectStart
+  , listCursorSelectEnd
+  , listCursorPrevItem
+  , listCursorNextItem
+  , listCursorPrevUntil
+  , listCursorNextUntil
+  , listCursorInsert
+  , listCursorAppend
+  , listCursorInsertList
+  , listCursorAppendList
+  , listCursorRemove
+  , listCursorDelete
+  , listCursorSplit
+  , listCursorCombine
+  , traverseListCursor
+  , foldListCursor
   )
 where
 
@@ -114,6 +116,28 @@ listCursorNextItem lc =
   case listCursorNext lc of
     [] -> Nothing
     (c : _) -> Just c
+
+listCursorPrevUntil :: (a -> Bool) -> ListCursor a -> ListCursor a
+listCursorPrevUntil p' = go p'
+  where
+    go :: (a -> Bool) -> ListCursor a -> ListCursor a
+    go p lc =
+      case listCursorPrev lc of
+        [] -> lc
+        (c:_)
+          | p c -> lc
+        _ -> maybe lc (go p) (listCursorSelectPrev lc)
+
+listCursorNextUntil :: (a -> Bool) -> ListCursor a -> ListCursor a
+listCursorNextUntil p' = go p'
+  where
+    go :: (a -> Bool) -> ListCursor a -> ListCursor a
+    go p lc =
+      case listCursorNext lc of
+        [] -> lc
+        (c:_)
+          | p c -> lc
+        _ -> maybe lc (go p) (listCursorSelectNext lc)
 
 listCursorInsert :: a -> ListCursor a -> ListCursor a
 listCursorInsert c lc = lc {listCursorPrev = c : listCursorPrev lc}

--- a/cursor/src/Cursor/TextField.hs
+++ b/cursor/src/Cursor/TextField.hs
@@ -20,6 +20,10 @@ module Cursor.TextField
     textFieldCursorSelectLastLine,
     textFieldCursorSelectPrevChar,
     textFieldCursorSelectNextChar,
+    textFieldCursorSelectPrevWord,
+    textFieldCursorSelectNextWord,
+    textFieldCursorSelectBeginWord,
+    textFieldCursorSelectEndWord,
     textFieldCursorIndexOnLine,
     textFieldCursorSelectIndexOnLine,
     textFieldCursorInsertChar,
@@ -146,6 +150,18 @@ textFieldCursorSelectPrevChar = textFieldCursorSelectedL textCursorSelectPrev
 
 textFieldCursorSelectNextChar :: TextFieldCursor -> Maybe TextFieldCursor
 textFieldCursorSelectNextChar = textFieldCursorSelectedL textCursorSelectNext
+
+textFieldCursorSelectBeginWord :: TextFieldCursor -> TextFieldCursor
+textFieldCursorSelectBeginWord = textFieldCursorSelectedL %~ textCursorSelectBeginWord
+
+textFieldCursorSelectEndWord :: TextFieldCursor -> TextFieldCursor
+textFieldCursorSelectEndWord = textFieldCursorSelectedL %~ textCursorSelectEndWord
+
+textFieldCursorSelectPrevWord :: TextFieldCursor -> TextFieldCursor
+textFieldCursorSelectPrevWord = textFieldCursorSelectedL %~ textCursorSelectPrevWord
+
+textFieldCursorSelectNextWord :: TextFieldCursor -> TextFieldCursor
+textFieldCursorSelectNextWord = textFieldCursorSelectedL %~ textCursorSelectNextWord
 
 textFieldCursorIndexOnLine :: TextFieldCursor -> Int
 textFieldCursorIndexOnLine tfc = textCursorIndex $ tfc ^. textFieldCursorSelectedL


### PR DESCRIPTION
Currently, text cursors only move one character at a time. In this PR, I added functions which allow you to move more than one character at a time. For example, using pseudo code to represent a cursor as a single string where `^` indicates the position of the cursor,

| example | result |
| :---: | :---: |
| beginWord "hell^o" | "^hello" |
| endWord "hell^o" | "hello^" |
| nextWord "hel^lo world" | "hello ^world" |
| prevWord "hello w^orld" | "hello^ world" |

### TODO

- [ ] Run ormolu (I previously ran hindent because I saw `.hindent.yaml`)
- [ ] Run hlint